### PR TITLE
Some improvements on conventions

### DIFF
--- a/lib/conjur/Conventions.groovy
+++ b/lib/conjur/Conventions.groovy
@@ -10,7 +10,6 @@ class Conventions {
       logRotator(-1, 30, -1, 30)
 
       wrappers {
-        preBuildCleanup()
         colorizeOutput()
         timestamps()
         timeout {
@@ -43,6 +42,7 @@ class Conventions {
             url(repoUrl)
           }
           branch('$BRANCH')
+          clean()
         }
       }
 

--- a/lib/conjur/Conventions.groovy
+++ b/lib/conjur/Conventions.groovy
@@ -26,6 +26,12 @@ class Conventions {
           notifyBackToNormal()
         }
       }
+
+      properties {
+        rebuild {
+          autoRebuild()
+        }
+      }
     }
   }
 


### PR DESCRIPTION
- Use git clean to clean the workspace instead of nuking the whole thing.
This way the whole repo doesn't have to be recloned every time.
- On clicking 'rebuild', don't ask for branch (just _re_build the one in the
chosen build).