### PR TITLE
Port the old release-rubgems job to Groovy DSL - WIP

### DIFF
--- a/jobs/release_rubygems.groovy
+++ b/jobs/release_rubygems.groovy
@@ -1,0 +1,20 @@
+use(conjur.Conventions) {
+  def job = job('release-rubygems') {
+    description('Releases a rubygems using release-bot https://github.com/conjurinc/release-bot')
+
+    parameters {
+      stringParam('GEM_NAME', '', 'Ruby Gem Name. Must be whitelisted in release-bot!')
+    }
+
+    steps {
+      shell('''
+        set -e
+
+        auth_header=`/opt/conjur/bin/conjur authn authenticate -H`
+        curl -f -H "$auth_header" -X POST "https://releasebot-conjur.herokuapp.com/rubygems/releases" --data "name=$GEM_NAME"
+      '''.stripIndent())
+    }
+  }
+  job.applyCommonConfig()
+  job.setBuildName('#${BUILD_NUMBER} ${ENV,var="GEM_NAME"}')
+}


### PR DESCRIPTION
@dustinmm80: I'd like to cleanup the shell call a bit to make it more generic and reusable.  Before I do that, do you mind taking a look through and making sure I'm not wildly off base?

#### What's this PR do?
Ports the old Jenkins job that handles the push to Ruby Gems to the new Groovy DSL

#### Where should the reviewer start?
`jobs/release_rubygems.groovy`

#### How should this be manually tested?
The job should be run on Jenkins and verified to have updated the gem in RubyGems.org

#### Any background context you want to provide?
New to Groovy and Jenkins, so the more feedback, the better!

#### What are the relevant tickets?
[CON-3507](https://conjurinc.atlassian.net/browse/CON-3507)

#### Reviewers
@dustinmm80 
